### PR TITLE
add --partition option to listen command

### DIFF
--- a/bin/streamr-listen.js
+++ b/bin/streamr-listen.js
@@ -6,6 +6,7 @@ const { envOptions, exitWitHelpIfArgsNotBetween, formStreamrOptionsWithEnv } = r
 program
     .usage('<streamId> [apiKey]')
     .description('subscribe and listen to a stream, prints JSON messages to stdout line-by-line')
+    .option('-p, --partition [partition]', 'partition', (s) => parseInt(s), 0)
 envOptions(program)
     .version(require('../package.json').version)
     .parse(process.argv)
@@ -13,4 +14,4 @@ envOptions(program)
 exitWitHelpIfArgsNotBetween(program, 1, 2)
 
 const options = formStreamrOptionsWithEnv(program)
-listen(program.args[0], program.args[1], options)
+listen(program.args[0], program.partition, program.args[1], options)

--- a/src/listen.js
+++ b/src/listen.js
@@ -1,12 +1,13 @@
 const StreamrClient = require('streamr-client')
 
-module.exports = function listen(stream, apiKey, streamrOptions) {
+module.exports = function listen(stream, partition, apiKey, streamrOptions) {
     const options = { ...streamrOptions }
     if (apiKey != null) {
         options.auth = { apiKey }
     }
     new StreamrClient(options).subscribe({
         stream,
+        partition,
         apiKey
     }, (message, metadata) => console.info(JSON.stringify(message)))
 }


### PR DESCRIPTION
Command `listen` now support listening to other partitions than just 0. Use option `--partition [number]` to specify a partition. 