### PR TITLE
create: add ability to define partition count

### DIFF
--- a/bin/streamr-create.js
+++ b/bin/streamr-create.js
@@ -8,6 +8,7 @@ program
     .description('create a new stream')
     .option('-d, --description <description>', 'define a description')
     .option('-c, --config <config>', 'define a configuration as JSON', (s) => JSON.parse(s))
+    .option('-p, --partitions <config>', 'define a partition count', (s) => parseInt(s))
 envOptions(program)
     .version(require('../package.json').version)
     .parse(process.argv)
@@ -23,7 +24,10 @@ if ("description" in program) {
 if ("config" in program) {
     body.config = program.config
 }
+if ("partitions" in program) {
+    body.partitions = program.partitions
+}
 
-const options = formStreamrOptionsWithEnv(program)
+const options = formStreamrOptionsWithEnv(program);
 create(body, program.args[1], options)
 

--- a/bin/streamr-create.js
+++ b/bin/streamr-create.js
@@ -28,6 +28,6 @@ if ("partitions" in program) {
     body.partitions = program.partitions
 }
 
-const options = formStreamrOptionsWithEnv(program);
+const options = formStreamrOptionsWithEnv(program)
 create(body, program.args[1], options)
 

--- a/bin/streamr-list.js
+++ b/bin/streamr-list.js
@@ -30,6 +30,6 @@ if ("grantedAccess" in program) {
     query.grantedAccess = program.grantedAccess
 }
 
-const options = formStreamrOptionsWithEnv(program);
+const options = formStreamrOptionsWithEnv(program)
 list(program.args[0], query, options)
 

--- a/bin/streamr-list.js
+++ b/bin/streamr-list.js
@@ -30,6 +30,6 @@ if ("grantedAccess" in program) {
     query.grantedAccess = program.grantedAccess
 }
 
-const options = formStreamrOptionsWithEnv(program)
+const options = formStreamrOptionsWithEnv(program);
 list(program.args[0], query, options)
 


### PR DESCRIPTION
Add option to streamr-create command to define the partition count of a stream.

Usage example:
```
streamr create my-stream-name tester1-api-key --partitions=10
```