### PR TITLE
publish: support partitionKey option

### DIFF
--- a/bin/streamr-publish.js
+++ b/bin/streamr-publish.js
@@ -7,6 +7,7 @@ const { envOptions, exitWitHelpIfArgsNotBetween, formStreamrOptionsWithEnv } = r
 program
     .usage('<streamId> <apiKey>')
     .description('publish to a stream by reading JSON messages from stdin line-by-line')
+    .option('-k, --partitionKey <string>', 'key for calculating partition to publish message to')
 envOptions(program)
     .version(require('../package.json').version)
     .parse(process.argv)
@@ -14,7 +15,7 @@ envOptions(program)
 exitWitHelpIfArgsNotBetween(program, 2, 2)
 
 const options = formStreamrOptionsWithEnv(program)
-const ps = publishStream(program.args[0], program.args[1], options)
+const ps = publishStream(program.args[0], program.args[1], program.partitionKey, options)
 process.stdin
     .pipe(es.split())
     .pipe(ps)

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,7 +1,7 @@
 const Writable = require('stream').Writable
 const StreamrClient = require('streamr-client')
 
-module.exports = function publishStream(stream, apiKey, streamrOptions) {
+module.exports = function publishStream(stream, apiKey, partitionKey, streamrOptions) {
     const options = { ...streamrOptions }
     if (apiKey != null) {
         options.auth = { apiKey }
@@ -25,7 +25,7 @@ module.exports = function publishStream(stream, apiKey, streamrOptions) {
                 return
             }
 
-            client.publish(stream, json, Date.now()).then(
+            client.publish(stream, json, Date.now(), partitionKey).then(
                 () => done(),
                 (err) => done(err)
             )


### PR DESCRIPTION
Fixes #19


Support specifying a partitionKey when publishing data with `streamr-publish` command.

Usage example:
```
streamr publish streamId apiKey --partitionKey=key
```