### PR TITLE
validate integer options and arguments

### DIFF
--- a/bin/common.js
+++ b/bin/common.js
@@ -38,8 +38,20 @@ function formStreamrOptionsWithEnv({ dev, stg, wsUrl, httpUrl }) {
     return options
 }
 
+function createFnParseInt(name) {
+    return (str) => {
+        const n = parseInt(str, 10)
+        if (isNaN(n)) {
+            console.error(`${name} must be an integer (was "${str}")`)
+            process.exit(1)
+        }
+        return n
+    }
+}
+
 module.exports = {
     envOptions,
     exitWitHelpIfArgsNotBetween,
-    formStreamrOptionsWithEnv
+    formStreamrOptionsWithEnv,
+    createFnParseInt
 }

--- a/bin/streamr-create.js
+++ b/bin/streamr-create.js
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
 const program = require('commander')
 const create = require('../src/create')
-const { envOptions, exitWitHelpIfArgsNotBetween, formStreamrOptionsWithEnv } = require('./common')
+const {
+    envOptions,
+    exitWitHelpIfArgsNotBetween,
+    formStreamrOptionsWithEnv,
+    createFnParseInt
+} = require('./common')
 
 program
     .usage('<name> <apiKey>')
     .description('create a new stream')
     .option('-d, --description <description>', 'define a description')
     .option('-c, --config <config>', 'define a configuration as JSON', (s) => JSON.parse(s))
-    .option('-p, --partitions <count>', 'define a partition count', (s) => parseInt(s))
+    .option('-p, --partitions <count>', 'define a partition count',
+        createFnParseInt('--partitions'))
 envOptions(program)
     .version(require('../package.json').version)
     .parse(process.argv)

--- a/bin/streamr-generate.js
+++ b/bin/streamr-generate.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 const program = require('commander')
 const generate = require('../src/generate')
-const { exitWitHelpIfArgsNotBetween } = require('./common')
+const { exitWitHelpIfArgsNotBetween, createFnParseInt } = require('./common')
 
 program
     .description('generate and print semi-random JSON data to stdout')
-    .option('-r, --rate <n>', 'rate in milliseconds',(s) => parseInt(s), 500)
+    .option('-r, --rate <n>', 'rate in milliseconds', createFnParseInt('--rate'), 500)
     .version(require('../package.json').version)
     .parse(process.argv)
 

--- a/bin/streamr-listen.js
+++ b/bin/streamr-listen.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 const program = require('commander')
 const listen = require('../src/listen')
-const { envOptions, exitWitHelpIfArgsNotBetween, formStreamrOptionsWithEnv } = require('./common')
+const { envOptions, exitWitHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt } = require('./common')
 
 program
     .usage('<streamId> [apiKey]')
     .description('subscribe and listen to a stream, prints JSON messages to stdout line-by-line')
-    .option('-p, --partition [partition]', 'partition', (s) => parseInt(s), 0)
+    .option('-p, --partition [partition]', 'partition', createFnParseInt('--partition'), 0)
 envOptions(program)
     .version(require('../package.json').version)
     .parse(process.argv)


### PR DESCRIPTION
Validate integer options and arguments and exit program with user-friendly error message if given argument is not parseable into an integer.

Fixes #20 