### PR TITLE
use kebab-case for --api-key and --private-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Turn option `--privateKey` into `--private-key` for consistency.
+- Turn `--apiKey` into `--api-key` for consistency.
 
 ## [4.0.0] - 2020-06-18
 ### Added

--- a/bin/common.js
+++ b/bin/common.js
@@ -8,8 +8,8 @@ function envOptions(program) {
 
 function authOptions(program) {
     return program
-        .option('--privateKey <key>', 'use an Ethereum private key to authenticate')
-        .option('--apiKey <key>', 'use an API key to authenticate (deprecated)')
+        .option('--private-key <key>', 'use an Ethereum private key to authenticate')
+        .option('--api-key <key>', 'use an API key to authenticate (deprecated)')
 }
 
 function exitWitHelpIfArgsNotBetween(program, min, max) {


### PR DESCRIPTION
To stay consistent with rest of options, use kebab case for new options --api-key and --private-key.