### PR TITLE
New commands for permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `streamr resend` is now `streamr stream resend`
   - `streamr generate` is now `streamr mock-data generate`
 - Add storage node commands under `streamr storage-node`
+- Add permission commands: `stream grant-permission` and `stream revoke-permission`
 - Implementation was converted to TypeScript
 - Bump dependency streamr-client to 5.2.1
 - Bump dependency commander to 7.2.0

--- a/bin/streamr-stream-grant-permission.ts
+++ b/bin/streamr-stream-grant-permission.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node -r ts-node/register
+import { Command } from 'commander';
+import {
+    envOptions,
+    authOptions,
+    formStreamrOptionsWithEnv
+} from './common'
+import pkg from '../package.json'
+import { AnonymousStreamPermisson, StreamOperation, StreamrClient, UserStreamPermission } from 'streamr-client';
+import EasyTable from 'easy-table'
+
+const PUBLIC_PERMISSION_ID = 'public'
+
+const OPERATIONS: Record<string,StreamOperation> = {
+    'get': StreamOperation.STREAM_GET,
+    'edit': StreamOperation.STREAM_EDIT,
+    'delete': StreamOperation.STREAM_DELETE,
+    'publish': StreamOperation.STREAM_PUBLISH,
+    'subscribe': StreamOperation.STREAM_SUBSCRIBE,
+    'share': StreamOperation.STREAM_SHARE
+}
+
+const getOperation = (id: string) => {
+    const operation = OPERATIONS[id]
+    if (operation === undefined) {
+        console.error(`error: invalid operation: ${id}`)
+        process.exit(1)
+    }
+    return operation
+}
+
+const getOperationId = (operation: StreamOperation) => {
+    for (let id of Object.keys(OPERATIONS)) {
+        if (OPERATIONS[id] === operation) {
+            return id
+        }
+    }
+}
+
+const getTarget = (user: string): string|undefined => {
+    if (user === PUBLIC_PERMISSION_ID) {
+        return undefined
+    } else {
+        return user
+    }
+}
+
+const program = new Command();
+program
+    .arguments('<streamId> <user> <operations...>')
+    .description('grant permission: use keyword "public" as a user to grant a public permission')
+authOptions(program)
+envOptions(program)
+    .version(pkg.version)
+    .action(async (streamId: string, user: string, operationIds: string[], options: any) => {
+        const operations = operationIds.map((o: string) => getOperation(o))
+        const target = getTarget(user)
+        const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const stream = await client.getStream(streamId)
+        const tasks = operations.map((operation: StreamOperation) => stream.grantPermission(operation, target))
+        const permissions = await Promise.all(tasks)
+        console.info(EasyTable.print(permissions.map((permission: UserStreamPermission|AnonymousStreamPermisson) => ({
+            id: permission.id,
+            operation: getOperationId(permission.operation),
+            user: (permission as AnonymousStreamPermisson).anonymous ? PUBLIC_PERMISSION_ID : (permission as UserStreamPermission).user
+        }))))
+    })
+    .parseAsync(process.argv)

--- a/bin/streamr-stream-list.ts
+++ b/bin/streamr-stream-list.ts
@@ -8,6 +8,7 @@ const program = new Command();
 program
     .description('fetch a list of streams that are accessible by the authenticated user')
     .option('-s, --search [term]', 'search for term in name or description')
+    // TODO could support shorter forms of operations: e.g. "publish" instead of "stream_publish", see streamr-stream-grant-permission.ts
     .addOption(new Option('-o, --operation [permission]', 'filter by permission').choices(['stream_get','stream_subscribe','stream_publish','stream_delete','stream_share']).default('stream_get'))
     .option('--public-access', 'include publicly available streams')
     .option('--no-granted-access', 'exclude streams that user has directly granted permissions to')

--- a/bin/streamr-stream-revoke-permission.ts
+++ b/bin/streamr-stream-revoke-permission.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node -r ts-node/register
+import { Command } from 'commander';
+import {
+    envOptions,
+    authOptions,
+    exitWithHelpIfArgsNotBetween,
+    formStreamrOptionsWithEnv
+} from './common'
+import pkg from '../package.json'
+import { StreamrClient } from 'streamr-client';
+
+const program = new Command();
+program
+    .arguments('<streamId> <permissionId>')
+    .description('grant permission: use keyword "public" as a user to grant a public permission')
+authOptions(program)
+envOptions(program)
+    .version(pkg.version)
+    .action(async (streamId: string, permissionId: number, options: any) => {
+        const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const stream = await client.getStream(streamId)
+        stream.revokePermission(permissionId)
+    })
+    .parseAsync(process.argv)
+
+exitWithHelpIfArgsNotBetween(program, 2, 2)

--- a/bin/streamr-stream-revoke-permission.ts
+++ b/bin/streamr-stream-revoke-permission.ts
@@ -12,7 +12,7 @@ import { StreamrClient } from 'streamr-client';
 const program = new Command();
 program
     .arguments('<streamId> <permissionId>')
-    .description('grant permission: use keyword "public" as a user to grant a public permission')
+    .description('revoke permission')
 authOptions(program)
 envOptions(program)
     .version(pkg.version)

--- a/bin/streamr-stream.ts
+++ b/bin/streamr-stream.ts
@@ -12,4 +12,6 @@ program
     .command('show', 'info about a stream')
     .command("create", "create a new stream")
     .command('resend', 'request resend of a stream')
+    .command('grant-permission', 'grant permission')
+    .command('revoke-permission', 'revoke permission')
     .parse(process.argv)


### PR DESCRIPTION
New `grant-permission` and `revoke-permission` commands:
```
 streamr stream grant-permission streamId 0x12345678 share
 streamr stream grant-permission streamId public publish get
 streamr stream revoke-permission streamId 12345
```