### PR TITLE
Build typescript into dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `streamr resend` is now `streamr stream resend`
   - `streamr generate` is now `streamr mock-data generate`
 - Add storage node commands under `streamr storage-node`
+- Fixed usage of private-key in README examples
 - Implementation was converted to TypeScript
 - Bump dependency streamr-client to 5.2.1
 - Bump dependency commander to 7.2.0

--- a/bin/streamr-mock-data-generate.ts
+++ b/bin/streamr-mock-data-generate.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { generate } from '../src/generate'
 import { exitWithHelpIfArgsNotBetween, createFnParseInt } from './common'

--- a/bin/streamr-mock-data.ts
+++ b/bin/streamr-mock-data.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { program } from 'commander'
 import pkg from '../package.json'
 

--- a/bin/streamr-storage-node-add-stream.ts
+++ b/bin/streamr-storage-node-add-stream.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { StreamrClient, Stream } from 'streamr-client'
 import {

--- a/bin/streamr-storage-node-list-stream-parts.ts
+++ b/bin/streamr-storage-node-list-stream-parts.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { StreamrClient, StreamPart } from 'streamr-client'
 import {

--- a/bin/streamr-storage-node-list.ts
+++ b/bin/streamr-storage-node-list.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { StreamrClient, StreamPart } from 'streamr-client'
 import {

--- a/bin/streamr-storage-node-remove-stream.ts
+++ b/bin/streamr-storage-node-remove-stream.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { StreamrClient, Stream } from 'streamr-client'
 import {

--- a/bin/streamr-storage-node.ts
+++ b/bin/streamr-storage-node.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { program } from 'commander'
 import pkg from '../package.json'
 

--- a/bin/streamr-stream-create.ts
+++ b/bin/streamr-stream-create.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { create } from '../src/create'
 import {

--- a/bin/streamr-stream-list.ts
+++ b/bin/streamr-stream-list.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command, Option } from 'commander';
 import { list } from '../src/list'
 import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv } from './common'

--- a/bin/streamr-stream-publish.ts
+++ b/bin/streamr-stream-publish.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import es from 'event-stream'
 import { publishStream } from '../src/publish'

--- a/bin/streamr-stream-resend.ts
+++ b/bin/streamr-stream-resend.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { StreamrClientOptions } from 'streamr-client';
 import { resend } from '../src/resend'

--- a/bin/streamr-stream-show.ts
+++ b/bin/streamr-stream-show.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { show } from '../src/show'
 import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv } from './common'

--- a/bin/streamr-stream-subscribe.ts
+++ b/bin/streamr-stream-subscribe.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander';
 import { subscribe } from '../src/subscribe'
 import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt } from './common'

--- a/bin/streamr-stream.ts
+++ b/bin/streamr-stream.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { program } from 'commander'
 import pkg from '../package.json'
 

--- a/bin/streamr.ts
+++ b/bin/streamr.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { program } from 'commander'
 import pkg from '../package.json'
 

--- a/package.json
+++ b/package.json
@@ -3,21 +3,7 @@
   "version": "4.1.1",
   "description": "Command line tools for Streamr.",
   "bin": {
-    "streamr": "dist/bin/streamr.js",
-    "streamr-stream": "dist/bin/streamr-stream.js",
-    "streamr-stream-create": "dist/bin/streamr-stream-create.js",
-    "streamr-stream-list": "dist/bin/streamr-stream-list.js",
-    "streamr-stream-publish": "dist/bin/streamr-stream-publish.js",
-    "streamr-stream-resend": "dist/bin/streamr-stream-resend.js",
-    "streamr-stream-show": "dist/bin/streamr-stream-show.js",
-    "streamr-stream-subscribe": "dist/bin/streamr-stream-subscribe.js",
-    "streamr-mock-data": "dist/bin/streamr-mock-data.js",
-    "streamr-mock-data-generate": "dist/bin/streamr-mock-data-generate.js",
-    "streamr-storage-node": "dist/bin/streamr-storage-node.js",
-    "streamr-storage-node-add-stream": "dist/bin/streamr-storage-node-add-stream.js",
-    "streamr-storage-node-list-stream-parts": "dist/bin/streamr-storage-node-list-stream-parts.js",
-    "streamr-storage-node-list": "dist/bin/streamr-storage-node-list.js",
-    "streamr-storage-node-remove-stream": "dist/bin/streamr-storage-node-remove-stream.js"
+    "streamr": "dist/bin/streamr.js"
   },
   "scripts": {
     "prepare": "tsc",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,25 @@
   "version": "4.1.1",
   "description": "Command line tools for Streamr.",
   "bin": {
-    "streamr": "bin/streamr.ts",
-    "streamr-create": "bin/streamr-create.ts",
-    "streamr-generate": "bin/streamr-generate.ts",
-    "streamr-list": "bin/streamr-list.ts",
-    "streamr-publish": "bin/streamr-publish.ts",
-    "streamr-resend": "bin/streamr-resend.ts",
-    "streamr-subscribe": "bin/streamr-subscribe.ts",
-    "streamr-show": "bin/streamr-show.ts"
+    "streamr": "dist/bin/streamr.js",
+    "streamr-stream": "dist/bin/streamr-stream.js",
+    "streamr-stream-create": "dist/bin/streamr-stream-create.js",
+    "streamr-stream-list": "dist/bin/streamr-stream-list.js",
+    "streamr-stream-publish": "dist/bin/streamr-stream-publish.js",
+    "streamr-stream-resend": "dist/bin/streamr-stream-resend.js",
+    "streamr-stream-show": "dist/bin/streamr-stream-show.js",
+    "streamr-stream-subscribe": "dist/bin/streamr-stream-subscribe.js",
+    "streamr-mock-data": "dist/bin/streamr-mock-data.js",
+    "streamr-mock-data-generate": "dist/bin/streamr-mock-data-generate.js",
+    "streamr-storage-node": "dist/bin/streamr-storage-node.js",
+    "streamr-storage-node-add-stream": "dist/bin/streamr-storage-node-add-stream.js",
+    "streamr-storage-node-list-stream-parts": "dist/bin/streamr-storage-node-list-stream-parts.js",
+    "streamr-storage-node-list": "dist/bin/streamr-storage-node-list.js",
+    "streamr-storage-node-remove-stream": "dist/bin/streamr-storage-node-remove-stream.js"
   },
   "scripts": {
+    "prepare": "tsc",
+    "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "esnext",
     "module": "commonjs",
     "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
     "rootDirs": ["src", "bin"],
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Basically I noticed that when doing `npm link` the project would not install properly. This was due to the whole `-r ts-node/register` not working on globally installed packages. Installing `ts-node` globally wasn't of any help either. Using the shebang `#!/usr/bin/env ts-node-script` sort of worked (commands `streamr`, `streamr-stream`, `streamr-mock-data` worked but `streamr stream` and `streamr mock-data` did not).

I noticed also that when running commands with `-r ts-node/register` it would take lot of time to start, presumably because of compilation.

So just went with compiling the TS files into JS files under `dist` like in our other projects. This gets around the whole issue of `ts-register` / shebang, but also makes the scripts run faster.